### PR TITLE
Use FloatProperty instead of EnumProperty for arbitrary resolution setting

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -465,16 +465,20 @@ class AIR_OT_show_other_dimension_options(bpy.types.Operator):
 
     panel_width = 250
 
-    width: bpy.props.EnumProperty(
+    width: bpy.props.FloatProperty(
         name="Image Width",
-        default="512",
-        items=valid_dimensions_tuple_list,
+        default=512,
+        step=6400,
+        precision=0,
+        min=512,
         description="Image Width"
     )
-    height: bpy.props.EnumProperty(
+    height: bpy.props.FloatProperty(
         name="Image Height",
-        default="512",
-        items=valid_dimensions_tuple_list,
+        default=512,
+        step=6400,
+        precision=0,
+        min=512,
         description="Image Height"
     )
 

--- a/operators.py
+++ b/operators.py
@@ -308,7 +308,8 @@ def validate_params(scene):
     return True
 
 def validate_resolution(self,context):
-    self.width = 512
+    self.width = round(self.width/64)*64
+    self.height = round(self.height/64)*64
 
 def validate_animation_output_path(scene):
     props = scene.air_props

--- a/operators.py
+++ b/operators.py
@@ -14,7 +14,6 @@ from .sd_backends.dreamstudio import dreamstudio_api
 from .sd_backends.automatic1111 import automatic1111_api
 
 
-valid_dimensions_tuple_list = utils.generate_valid_dimensions_tuple_list()
 
 
 def enable_air(scene):

--- a/operators.py
+++ b/operators.py
@@ -469,7 +469,7 @@ class AIR_OT_show_other_dimension_options(bpy.types.Operator):
         default=512,
         step=6400,
         precision=0,
-        min=512,
+        min=384,
         description="Image Width"
     )
     height: bpy.props.FloatProperty(
@@ -477,7 +477,7 @@ class AIR_OT_show_other_dimension_options(bpy.types.Operator):
         default=512,
         step=6400,
         precision=0,
-        min=512,
+        min=384,
         description="Image Height"
     )
 

--- a/operators.py
+++ b/operators.py
@@ -308,7 +308,7 @@ def validate_params(scene):
     return True
 
 def validate_resolution(self,context):
-    print(self)
+    print(self.width)
 
 def validate_animation_output_path(scene):
     props = scene.air_props

--- a/operators.py
+++ b/operators.py
@@ -308,7 +308,7 @@ def validate_params(scene):
     return True
 
 def validate_resolution(self,context):
-    print(self.width)
+    self.width = 512
 
 def validate_animation_output_path(scene):
     props = scene.air_props

--- a/operators.py
+++ b/operators.py
@@ -308,8 +308,9 @@ def validate_params(scene):
     return True
 
 def validate_resolution(self,context):
-    self.width = round(self.width/64)*64
-    self.height = round(self.height/64)*64
+    if self.width%64!=0 or self.height%64!=0:
+        self.width = round(self.width/64)*64
+        self.height = round(self.height/64)*64
 
 def validate_animation_output_path(scene):
     props = scene.air_props

--- a/operators.py
+++ b/operators.py
@@ -307,6 +307,8 @@ def validate_params(scene):
         return handle_error("Please enter a prompt for Stable Diffusion", "prompt")
     return True
 
+def validate_resolution(self,context):
+    print(self)
 
 def validate_animation_output_path(scene):
     props = scene.air_props
@@ -470,7 +472,8 @@ class AIR_OT_show_other_dimension_options(bpy.types.Operator):
         step=6400,
         precision=0,
         min=384,
-        description="Image Width"
+        description="Image Width",
+        update= validate_resolution
     )
     height: bpy.props.FloatProperty(
         name="Image Height",
@@ -478,7 +481,8 @@ class AIR_OT_show_other_dimension_options(bpy.types.Operator):
         step=6400,
         precision=0,
         min=384,
-        description="Image Height"
+        description="Image Height",
+        update= validate_resolution
     )
 
     def draw(self, context):

--- a/utils.py
+++ b/utils.py
@@ -149,9 +149,6 @@ def are_dimensions_too_large(scene):
         return get_output_width(scene) * get_output_height(scene) > config.max_image_px_area
 
 
-def generate_valid_dimensions_tuple_list():
-    return_tuple = lambda num: (str(num), str(num) + " px", str(num))
-    return list(map(return_tuple, valid_dimensions))
 
 
 def has_url(text, strict_match_protocol=False):


### PR DESCRIPTION
Minimum set to 512, as lower values yield bad results. With step of 64, as required for SD. Using `FloatProperty` instead of `IntProperty` as the latter doesn't support the `step` parameter.
Removing `generate_valid_dimensions_tuple_list()` and references