### PR TITLE
Stable horde support

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -27,6 +27,7 @@ if "bpy" in locals():
     imp.reload(utils)
     imp.reload(automatic1111_api)
     imp.reload(dreamstudio_api)
+    imp.reload(stablehorde_api)
 else:
     from . import (
         addon_updater_ops,
@@ -45,6 +46,7 @@ else:
     )
     from .sd_backends.automatic1111 import automatic1111_api
     from .sd_backends.dreamstudio import dreamstudio_api
+    from .sd_backends.stablehorde import stablehorde_api
 
 import bpy
 

--- a/config.py
+++ b/config.py
@@ -10,6 +10,7 @@ request_timeout = 60
 API_URL = "https://c7vllddffse76obdapr6s2p4du0ydjrn.lambda-url.us-west-2.on.aws/"
 ADDON_DOWNLOAD_URL = "https://airender.gumroad.com/l/ai-render"
 DREAM_STUDIO_URL = "https://beta.dreamstudio.ai/membership?tab=apiKeys"
+STABLE_HORDE_URL = "https://stablehorde.net/"
 VIDEO_TUTORIAL_URL = "https://www.youtube.com/watch?v=tmyln5bwnO8"
 HELP_WITH_TIMEOUTS_URL = "https://github.com/benrugg/AI-Render/wiki/FAQ#%EF%B8%8F-ai-render-keeps-timing-out"
 HELP_WITH_LOCAL_INSTALLATION_URL = "https://github.com/benrugg/AI-Render/wiki/Local-Installation"

--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ workspace_id = 'AI Render'
 animated_prompts_text_name = 'AI Render Animated Prompts'
 max_image_px_area = 458752 # 896 x 512 or 960 x 448 (anything larger than this risks a timeout)
 
-request_timeout = 18
+request_timeout = 60
 
 API_URL = "https://c7vllddffse76obdapr6s2p4du0ydjrn.lambda-url.us-west-2.on.aws/"
 ADDON_DOWNLOAD_URL = "https://airender.gumroad.com/l/ai-render"

--- a/operators.py
+++ b/operators.py
@@ -14,6 +14,7 @@ from . import (
 
 from .sd_backends.dreamstudio import dreamstudio_api
 from .sd_backends.automatic1111 import automatic1111_api
+from .sd_backends.stablehorde import stablehorde_api
 
 
 valid_dimensions_tuple_list = utils.generate_valid_dimensions_tuple_list()
@@ -248,7 +249,7 @@ def render_frame(context, current_frame, prompt):
 
 def save_render_to_file(scene, filename_prefix):
     try:
-        temp_file = utils.create_temp_file(filename_prefix + "-")
+        temp_file = utils.create_temp_file(filename_prefix + "-", ".webp")
     except:
         return handle_error("Couldn't create temp file for image")
 
@@ -257,7 +258,7 @@ def save_render_to_file(scene, filename_prefix):
         orig_render_color_mode = scene.render.image_settings.color_mode
         orig_render_color_depth = scene.render.image_settings.color_depth
 
-        scene.render.image_settings.file_format = 'PNG'
+        scene.render.image_settings.file_format = 'WEBP'
         scene.render.image_settings.color_mode = 'RGBA'
         scene.render.image_settings.color_depth = '8'
 
@@ -411,6 +412,7 @@ def validate_and_process_animated_prompt_text_for_single_frame(scene, frame):
 
 
 def send_to_api(scene, prompt=None):
+    print("Sending to API")
     """Post to the API and process the resulting image"""
     props = scene.air_props
 
@@ -468,7 +470,7 @@ def send_to_api(scene, prompt=None):
         else:
             return handle_error(f"You are trying to use a local Stable Diffusion installation that isn't supported: {utils.local_sd_backend()}")
     else:
-        output_file = dreamstudio_api.send_to_api(params, img_file, after_output_filename_prefix)
+        output_file = stablehorde_api.send_to_api(params, img_file, after_output_filename_prefix)
 
     # if we got a successful image created, handle it
     if output_file:

--- a/operators.py
+++ b/operators.py
@@ -464,13 +464,7 @@ def send_to_api(scene, prompt=None):
     }
 
     # send to whichever API we're using
-    if utils.do_use_local_sd():
-        if utils.local_sd_backend() == "automatic1111":
-            output_file = automatic1111_api.send_to_api(params, img_file, after_output_filename_prefix)
-        else:
-            return handle_error(f"You are trying to use a local Stable Diffusion installation that isn't supported: {utils.local_sd_backend()}")
-    else:
-        output_file = stablehorde_api.send_to_api(params, img_file, after_output_filename_prefix)
+    output_file = utils.get_active_backend().send_to_api(params, img_file, after_output_filename_prefix)
 
     # if we got a successful image created, handle it
     if output_file:

--- a/operators.py
+++ b/operators.py
@@ -806,9 +806,12 @@ class AIR_OT_setup_instructions_popup(bpy.types.Operator):
         utils.label_multiline(self.layout, text=self.message, icon="HELP", width=self.width-3, alignment="CENTER")
         row = self.layout.row()
         row.operator("wm.url_open", text="Sign Up For DreamStudio (free)", icon="URL").url = config.DREAM_STUDIO_URL
+        row = self.layout.row()
+        row.operator("wm.url_open", text="Get a Stable Horde API key (free / not required)", icon="URL").url = config.STABLE_HORDE_URL
 
     def invoke(self, context, event):
-        self.message = "This add-on uses a service called DreamStudio. You will need to create a DreamStudio account, and get your own API KEY from them. You will get free credits, which will be used when you render. After using your free credits, you will need to sign up for a membership. DreamStudio is unaffiliated with this Blender add-on. It's just a great and easy to use option!"
+        self.message = ("This add-on uses a service called DreamStudio. You will need to create a DreamStudio account, and get your own API KEY from them. You will get free credits, which will be used when you render. After using your free credits, you will need to sign up for a membership. DreamStudio is unaffiliated with this Blender add-on. It's just a great and easy to use option!\n" +
+            "Alternatively, use the 'Stable Horde' crowdsourced distributed GPU cluster. It's free with unlimited generations and doesn't require registration, but it can be slower when demand is high. Create an api-key for faster rendering, and consider running a worker for even more speed and to help others with their renders!")
         return context.window_manager.invoke_props_dialog(self, width=self.width)
 
     def execute(self, context):

--- a/operators.py
+++ b/operators.py
@@ -249,7 +249,7 @@ def render_frame(context, current_frame, prompt):
 
 def save_render_to_file(scene, filename_prefix):
     try:
-        temp_file = utils.create_temp_file(filename_prefix + "-", ".webp")
+        temp_file = utils.create_temp_file(filename_prefix + "-", utils.get_active_backend().get_image_format().lower())
     except:
         return handle_error("Couldn't create temp file for image")
 
@@ -258,7 +258,7 @@ def save_render_to_file(scene, filename_prefix):
         orig_render_color_mode = scene.render.image_settings.color_mode
         orig_render_color_depth = scene.render.image_settings.color_depth
 
-        scene.render.image_settings.file_format = 'WEBP'
+        scene.render.image_settings.file_format = utils.get_active_backend().get_image_format()
         scene.render.image_settings.color_mode = 'RGBA'
         scene.render.image_settings.color_depth = '8'
 
@@ -331,8 +331,8 @@ def do_pre_api_setup(scene):
 
 
 def validate_params(scene, prompt=None):
-    if utils.get_api_key().strip() == "" and not utils.do_use_local_sd():
-        return handle_error("You must enter an API Key to render with Stable Diffusion", "api_key")
+    if utils.get_api_key().strip() == "" and utils.local_sd_backend() == "dreamstudio":
+        return handle_error("You must enter an API Key to render with the selected back-end", "api_key")
     if not utils.are_dimensions_valid(scene):
         return handle_error("Please set width and height to valid values", "dimensions")
     if utils.are_dimensions_too_large(scene):

--- a/preferences.py
+++ b/preferences.py
@@ -126,6 +126,12 @@ class AIRPreferences(bpy.types.AddonPreferences):
             row.operator("wm.url_open", text="Sign Up For DreamStudio (free)", icon="URL").url = config.DREAM_STUDIO_URL
 
             row = box.row()
+            col = row.column()
+            col.label(text="Stable Diffusion Backend:")
+            col = row.column()
+            col.prop(self, "local_sd_backend", text="")
+
+            row = box.row()
             row.prop(self, "dream_studio_api_key")
 
             # Notes

--- a/preferences.py
+++ b/preferences.py
@@ -128,6 +128,10 @@ class AIRPreferences(bpy.types.AddonPreferences):
             row.operator("wm.url_open", text="Sign Up For DreamStudio (free)", icon="URL").url = config.DREAM_STUDIO_URL
 
             row = box.row()
+            row.operator("wm.url_open", text="Get a Stable Horde API key (free / not required)", icon="URL").url \
+                = config.STABLE_HORDE_URL
+
+            row = box.row()
             col = row.column()
             col.label(text="Stable Diffusion Backend:")
             col = row.column()

--- a/preferences.py
+++ b/preferences.py
@@ -31,19 +31,21 @@ class AIRPreferences(bpy.types.AddonPreferences):
 
     is_local_sd_enabled: bpy.props.BoolProperty(
         name="Enable Rendering with Local Stable Diffusion",
-        description="When true, AI Render will use your local backend installation of Stable Diffusion. When false, DreamStudio will be used",
+        description="When true, AI Render will use your local backend installation of Stable Diffusion.",
         default=False,
         update=properties.ensure_sampler,
     )
 
     local_sd_backend: bpy.props.EnumProperty(
-        name="Local Stable Diffusion Backend",
-        default="automatic1111",
+        name="Stable Diffusion Backend",
+        default="dreamstudio",
         items=[
+            ('dreamstudio', 'Dream Studio', ''),
+            ('stablehorde', 'Stable Horde', ''),
             ('automatic1111', 'Automatic1111', ''),
         ],
         update=properties.ensure_sampler,
-        description="Which local Stable Diffusion installation you have",
+        description="Which Stable Diffusion back-end do you want to use?",
     )
 
     local_sd_url: bpy.props.StringProperty(
@@ -157,12 +159,6 @@ class AIRPreferences(bpy.types.AddonPreferences):
 
                 row = box.row()
                 row.prop(self, "is_local_sd_enabled")
-
-                row = box.row()
-                col = row.column()
-                col.label(text="Local Stable Diffusion Backend:")
-                col = row.column()
-                col.prop(self, "local_sd_backend", text="")
 
                 row = box.row()
                 col = row.column()

--- a/properties.py
+++ b/properties.py
@@ -6,7 +6,6 @@ from . import (
     utils,
 )
 from .ui import ui_preset_styles
-from .sd_backends.stablehorde import stablehorde_api
 
 
 def get_available_samplers(self, context):

--- a/properties.py
+++ b/properties.py
@@ -6,29 +6,15 @@ from . import (
     utils,
 )
 from .ui import ui_preset_styles
-from .sd_backends.dreamstudio import dreamstudio_api
-from .sd_backends.automatic1111 import automatic1111_api
+from .sd_backends.stablehorde import stablehorde_api
 
 
 def get_available_samplers(self, context):
-    if utils.do_use_local_sd():
-        if utils.local_sd_backend() == "automatic1111":
-            return automatic1111_api.get_samplers()
-        else:
-            print(f"You are trying to use a local Stable Diffusion installation that isn't supported: {utils.local_sd_backend()}")
-            return []
-    else:
-        return dreamstudio_api.get_samplers()
+    return utils.get_active_backend().get_samplers()
 
 
 def get_default_sampler():
-    if utils.do_use_local_sd():
-        if utils.local_sd_backend() == "automatic1111":
-            return automatic1111_api.default_sampler()
-        else:
-            return ""
-    else:
-        return dreamstudio_api.default_sampler()
+    return utils.get_active_backend().default_sampler()
 
 
 def ensure_sampler(self, context):

--- a/sd_backends/automatic1111/automatic1111_api.py
+++ b/sd_backends/automatic1111/automatic1111_api.py
@@ -11,6 +11,8 @@ from ... import (
 
 
 # CORE FUNCTIONS:
+def get_image_format():
+    return 'PNG'
 
 def send_to_api(params, img_file, filename_prefix):
 

--- a/sd_backends/dreamstudio/dreamstudio_api.py
+++ b/sd_backends/dreamstudio/dreamstudio_api.py
@@ -8,6 +8,8 @@ from ... import (
 
 
 # CORE FUNCTIONS:
+def get_image_format():
+    return 'PNG'
 
 def send_to_api(params, img_file, filename_prefix):
 

--- a/sd_backends/stablehorde/stablehorde_api.py
+++ b/sd_backends/stablehorde/stablehorde_api.py
@@ -24,8 +24,7 @@ def get_image_format():
 
 def send_to_api(params, img_file, filename_prefix):
 
-    # map the generic params to the specific ones for the Automatic1111 API
-    # map_params(params)
+    # map the generic params to the specific ones for the Stable Horde API
     stablehorde_params = {
         "prompt": params["prompt"],
         # add a base 64 encoded image to the params
@@ -44,12 +43,15 @@ def send_to_api(params, img_file, filename_prefix):
     #webp_filename.close()
     img_file.close()
 
+    # If no api-key specified, use the default non-authenticated api-key
+    apikey = utils.get_api_key() if not utils.get_api_key().strip() == "" else "0000000000"
+
     # create the headers
     headers = {
         "User-Agent": "Blender/" + bpy.app.version_string,
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate, br",
-        "apikey": utils.get_api_key()
+        "apikey": apikey
     }
 
     # send the API request

--- a/sd_backends/stablehorde/stablehorde_api.py
+++ b/sd_backends/stablehorde/stablehorde_api.py
@@ -16,16 +16,13 @@ SAMPLER_MAP = {
     "DDIM": "k_ddim",
     "PLMS": ""
 }
+
 # CORE FUNCTIONS:
 
-def send_to_api(params, img_file, filename_prefix):
+def get_image_format():
+    return 'WEBP'
 
-    # Open img_file png and convert to webp
-    # TODO: Change operators.py to render directly to webp
-    # image = PIL.Image.open(img_file)  # Open image
-    # webp_filename = img_file + ".webp"
-    # image.save(webp_filename, format="webp")  # Convert image to webp
-    print("Sending: " + str(img_file))
+def send_to_api(params, img_file, filename_prefix):
 
     # map the generic params to the specific ones for the Automatic1111 API
     # map_params(params)
@@ -40,7 +37,7 @@ def send_to_api(params, img_file, filename_prefix):
             "denoising_strength": round(1 - params["image_similarity"], 2),
             "seed": str(params["seed"]),
             "steps": params["steps"],
-            #"sampler_name": params["sampler"],
+            "sampler_name": params["sampler"],
         }
     }
 
@@ -141,30 +138,23 @@ def handle_api_error(response):
 
 
 def get_samplers():
-    def get_samplers():
-        # NOTE: Keep the number values (fourth item in the tuples) in sync with DreamStudio's
-        # values (in dreamstudio_apy.py). These act like an internal unique ID for Blender
-        # to use when switching between the lists.
-        return [
-            ('k_euler', 'Euler', '', 10),
-            ('k_euler_a', 'Euler a', '', 20),
-            ('k_heun', 'Heun', '', 30),
-            ('k_dpm_2', 'DPM2', '', 40),
-            ('k_dpm_2_a', 'DPM2 a', '', 50),
-            ('k_dpm_fast', 'DPM fast', '', 70),
-            ('k_dpm_adaptive', 'DPM adaptive', '', 80),
-            ('k_lms', 'LMS', '', 60),
-            ('k_dpmpp_2s_a', 'DPM++ 2S a', '', 110),
-            ('k_dpmpp_2m', 'DPM++ 2M', '', 120),
-            # TODO: Stable horde does have karras support, but it's a separate boolean
-        ]
+    # NOTE: Keep the number values (fourth item in the tuples) in sync with DreamStudio's
+    # values (in dreamstudio_apy.py). These act like an internal unique ID for Blender
+    # to use when switching between the lists.
+    return [
+        ('k_euler', 'Euler', '', 10),
+        ('k_euler_a', 'Euler a', '', 20),
+        ('k_heun', 'Heun', '', 30),
+        ('k_dpm_2', 'DPM2', '', 40),
+        ('k_dpm_2_a', 'DPM2 a', '', 50),
+        ('k_lms', 'LMS', '', 60),
+        ('k_dpm_fast', 'DPM fast', '', 70),
+        ('k_dpm_adaptive', 'DPM adaptive', '', 80),
+        ('k_dpmpp_2s_a', 'DPM++ 2S a', '', 110),
+        ('k_dpmpp_2m', 'DPM++ 2M', '', 120),
+        # TODO: Stable horde does have karras support, but it's a separate boolean
+    ]
 
 def default_sampler():
-    return 'Euler a'
+    return 'k_euler_a'
 
-
-# SUPPORT FUNCTIONS:
-
-def map_params(params):
-    params["denoising_strength"] = round(1 - params["image_similarity"], 2)
-    params["sampler_index"] = params["sampler"]

--- a/sd_backends/stablehorde/stablehorde_api.py
+++ b/sd_backends/stablehorde/stablehorde_api.py
@@ -1,0 +1,170 @@
+import bpy
+import json
+import base64
+import time
+import re
+import requests
+
+from ... import (
+    config,
+    operators,
+    utils,
+)
+
+API_URL = "https://stablehorde.net/api/v2/generate/sync"
+SAMPLER_MAP = {
+    "DDIM": "k_ddim",
+    "PLMS": ""
+}
+# CORE FUNCTIONS:
+
+def send_to_api(params, img_file, filename_prefix):
+
+    # Open img_file png and convert to webp
+    # TODO: Change operators.py to render directly to webp
+    # image = PIL.Image.open(img_file)  # Open image
+    # webp_filename = img_file + ".webp"
+    # image.save(webp_filename, format="webp")  # Convert image to webp
+    print("Sending: " + str(img_file))
+
+    # map the generic params to the specific ones for the Automatic1111 API
+    # map_params(params)
+    stablehorde_params = {
+        "prompt": params["prompt"],
+        # add a base 64 encoded image to the params
+        "source_image": base64.b64encode(img_file.read()).decode(),
+        "params": {
+            "cfg_scale": params["cfg_scale"],
+            "width": params["width"],
+            "height": params["height"],
+            "denoising_strength": round(1 - params["image_similarity"], 2),
+            "seed": str(params["seed"]),
+            "steps": params["steps"],
+            #"sampler_name": params["sampler"],
+        }
+    }
+
+    #webp_filename.close()
+    img_file.close()
+
+    # create the headers
+    headers = {
+        "User-Agent": "Blender/" + bpy.app.version_string,
+        "Accept": "*/*",
+        "Accept-Encoding": "gzip, deflate, br",
+        "apikey": utils.get_api_key()
+    }
+
+    # send the API request
+    # try:
+    #     response = requests.post(API_URL, json=params, headers=headers)
+    # except requests.exceptions.ConnectionError:
+    #     return operators.handle_error(f"The local Stable Diffusion server couldn't be found. It's either not running, or it's running at a different location than what you specified in the add-on preferences. [Get help]({config.HELP_WITH_LOCAL_INSTALLATION_URL})")
+    # except requests.exceptions.MissingSchema:
+    #     return operators.handle_error(f"The url for your local Stable Diffusion server is invalid. Please set it correctly in the add-on preferences. [Get help]({config.HELP_WITH_LOCAL_INSTALLATION_URL})")
+    # except requests.exceptions.ReadTimeout:
+    #     return operators.handle_error("The local Stable Diffusion server timed out. Set a longer timeout in AI Render preferences, or use a smaller image size.")
+
+    # send the API request
+    print("Sending to Stable Horde: " + str(stablehorde_params))
+    start_time = time.monotonic();
+    try:
+        response = requests.post(API_URL, json=stablehorde_params, headers=headers, timeout=config.request_timeout)
+        img_file.close()
+    except requests.exceptions.ReadTimeout:
+        img_file.close()
+        return operators.handle_error(f"The server timed out. Try again in a moment, or get help. [Get help with timeouts]({config.HELP_WITH_TIMEOUTS_URL})")
+    print("The horde took " + str(time.monotonic() - start_time) + " seconds to imagine this frame.")
+
+    # handle the response
+    if response.status_code == 200:
+        return handle_api_success(response, filename_prefix)
+    else:
+        return handle_api_error(response)
+
+
+def handle_api_success(response, filename_prefix):
+
+    # ensure we have the type of response we are expecting
+    try:
+        response_obj = response.json()
+        # print(str(response_obj))
+        # print(str(response_obj["generations"]))
+        # print(str(response_obj["generations"][0]))
+
+        base64_img = response_obj["generations"][0]["img"]
+    except:
+        print("Stable Horde response content: ")
+        print(response.content)
+        return operators.handle_error("Received an unexpected response from the Stable Horde server.")
+
+    # create a temp file
+    try:
+        output_file = utils.create_temp_file(filename_prefix + "-.webp")
+    except:
+        return operators.handle_error("Couldn't create a temp file to save image.")
+
+    # decode base64 image
+    try:
+        img_binary = base64.b64decode(base64_img.replace("data:image/png;base64,", ""))
+    except:
+        return operators.handle_error("Couldn't decode base64 image from the Automatic1111 Stable Diffusion server.")
+
+    # save the image to the temp file
+    try:
+        with open(output_file, 'wb') as file:
+            file.write(img_binary)
+    except:
+        return operators.handle_error("Couldn't write to temp file.")
+
+    # Convert the file from webp to png
+    # return the temp file
+    return output_file
+
+
+def handle_api_error(response):
+    return operators.handle_error("the Stable Horde server returned an error: " + str(response.content))
+    # if response.status_code == 404:
+    #     import json
+    #
+    #     try:
+    #         response_obj = response.json()
+    #         if response_obj.get('detail') and response_obj['detail'] == "Sampler not found":
+    #             return operators.handle_error("The sampler you selected is not available on the Automatic1111 Stable Diffusion server. Please select a different sampler.")
+    #         else:
+    #             return operators.handle_error(f"An error occurred in the Automatic1111 Stable Diffusion server. Full server response: {json.dumps(response_obj)}")
+    #     except:
+    #         return operators.handle_error(f"It looks like the Automatic1111 server is running, but it's not in API mode. [Get help]({config.HELP_WITH_AUTOMATIC1111_NOT_IN_API_MODE_URL})")
+    #
+    # else:
+    #     return operators.handle_error("An error occurred in the Automatic1111 Stable Diffusion server. Check the server logs for more info.")
+
+
+def get_samplers():
+    def get_samplers():
+        # NOTE: Keep the number values (fourth item in the tuples) in sync with DreamStudio's
+        # values (in dreamstudio_apy.py). These act like an internal unique ID for Blender
+        # to use when switching between the lists.
+        return [
+            ('k_euler', 'Euler', '', 10),
+            ('k_euler_a', 'Euler a', '', 20),
+            ('k_heun', 'Heun', '', 30),
+            ('k_dpm_2', 'DPM2', '', 40),
+            ('k_dpm_2_a', 'DPM2 a', '', 50),
+            ('k_dpm_fast', 'DPM fast', '', 70),
+            ('k_dpm_adaptive', 'DPM adaptive', '', 80),
+            ('k_lms', 'LMS', '', 60),
+            ('k_dpmpp_2s_a', 'DPM++ 2S a', '', 110),
+            ('k_dpmpp_2m', 'DPM++ 2M', '', 120),
+            # TODO: Stable horde does have karras support, but it's a separate boolean
+        ]
+
+def default_sampler():
+    return 'Euler a'
+
+
+# SUPPORT FUNCTIONS:
+
+def map_params(params):
+    params["denoising_strength"] = round(1 - params["image_similarity"], 2)
+    params["sampler_index"] = params["sampler"]

--- a/sd_backends/stablehorde/stablehorde_api.py
+++ b/sd_backends/stablehorde/stablehorde_api.py
@@ -64,7 +64,7 @@ def send_to_api(params, img_file, filename_prefix):
 
     # For debugging
     # print("Send to Stable Horde: " + str(stablehorde_params))
-    # print("Received from Stable Horde: " + str(response))
+    # print("Received from Stable Horde: " + str(response.json()))
 
     # handle the response
     if response.status_code == 200:
@@ -79,6 +79,9 @@ def handle_api_success(response, filename_prefix):
     try:
         response_obj = response.json()
         base64_img = response_obj["generations"][0]["img"]
+        print(f"Worker: {response_obj['generations'][0]['worker_name']}, " +
+              f"queue position: {response_obj['queue_position']}, wait time: {response_obj['wait_time']}, " +
+              f"kudos: {response_obj['kudos']}")
     except:
         print("Stable Horde response content: ")
         print(response.content)

--- a/utils.py
+++ b/utils.py
@@ -23,6 +23,9 @@ import os
 import shutil
 import tempfile
 from . import config
+from .sd_backends.dreamstudio import dreamstudio_api
+from .sd_backends.automatic1111 import automatic1111_api
+from .sd_backends.stablehorde import stablehorde_api
 
 
 valid_dimensions = [384, 448, 512, 576, 640, 704, 768, 832, 896, 960, 1024]
@@ -154,6 +157,8 @@ def do_use_local_sd(context=None):
 
 
 def local_sd_backend(context=None):
+    print(str(get_addon_preferences(context)))
+    print(str(get_addon_preferences(context).local_sd_backend))
     return get_addon_preferences(context).local_sd_backend
 
 
@@ -313,6 +318,15 @@ def label_multiline(layout, text='', icon='NONE', width=-1, max_lines=12, use_ur
     return rows
 
 
+def get_active_backend():
+    if local_sd_backend() == "dreamstudio":
+        return dreamstudio_api
+    elif local_sd_backend() == "stablehorde":
+        return stablehorde_api
+    elif local_sd_backend() == "automatic1111":
+        return automatic1111_api
+
+
 def is_installation_valid():
     return __package__ == config.package_name
 
@@ -322,3 +336,4 @@ def show_invalid_installation_message(layout, width):
     box.label(text="Installation Error:")
 
     label_multiline(box, text=f"It looks like this add-on wasn't installed correctly. Please remove it and get a new copy. [Get AI Render]({config.ADDON_DOWNLOAD_URL})", icon="ERROR", alert=True, width=width)
+

--- a/utils.py
+++ b/utils.py
@@ -157,8 +157,6 @@ def do_use_local_sd(context=None):
 
 
 def local_sd_backend(context=None):
-    print(str(get_addon_preferences(context)))
-    print(str(get_addon_preferences(context).local_sd_backend))
     return get_addon_preferences(context).local_sd_backend
 
 


### PR DESCRIPTION
This PR adds support for the Stable Horde crowdsourced distributed GPU cluster to AI Render.

- Wrote the Stable Horde SD back-end
- Stable Horde requires the webp image format for sending and receiving, so made the image format dynamic based on selected back-end
- Changed configuration screen to add backend selection drop-down at the top. Back-end selection now isn't only for Local back-ends, but includes remote backends (Dream Studio, Stable Horde) as well.
- If no api-key given for Stable Horde, use the 'anonymous' (0000000000) one as default
- Added some documentation