### PR TITLE
Expose ControlNet weight parameter to the interface

### DIFF
--- a/properties.py
+++ b/properties.py
@@ -242,6 +242,15 @@ class AIRProperties(bpy.types.PropertyGroup):
         default=False,
         description="When true, will use ControlNet for each rendered image",
     )
+    controlnet_weight: bpy.props.FloatProperty(
+        name="ControlNet Weight",
+        default=1.0,
+        soft_min=0.0,
+        soft_max=1.0,
+        min=0.0,
+        max=2.0,
+        description="How much influence ControlNet will have on guiding the rendered image output",
+    )
     controlnet_close_help: bpy.props.BoolProperty(
         name="Close ControlNet Help",
         default=False,

--- a/sd_backends/automatic1111_api.py
+++ b/sd_backends/automatic1111_api.py
@@ -23,6 +23,7 @@ def generate(params, img_file, filename_prefix, props):
     if props.controlnet_is_enabled:
         controlnet_model = props.controlnet_model
         controlnet_module = props.controlnet_module
+        controlnet_weight = props.controlnet_weight
 
         if not controlnet_model:
             return operators.handle_error(f"No ContolNet model selected. Either choose a new model or disable ControlNet. [Get help]({config.HELP_WITH_CONTROLNET_URL})", "controlnet_model_missing")
@@ -31,6 +32,7 @@ def generate(params, img_file, filename_prefix, props):
             "controlnet": {
                 "args": [
                     {
+                    "weight": controlnet_weight,
                     "module": controlnet_module,
                     "model": controlnet_model
                     }

--- a/ui/ui_panels.py
+++ b/ui/ui_panels.py
@@ -351,6 +351,14 @@ class AIR_PT_controlnet(bpy.types.Panel):
             split = row.split(align=True)
             split.operator(operators.AIR_OT_automatic1111_load_controlnet_models.bl_idname, text="", icon="FILE_REFRESH")
 
+        # Weight
+        row = layout.row()
+        sub = row.column()
+        sub.label(text="Weight")
+        sub = row.column()
+        sub.prop(props, 'controlnet_weight', text="", slider=False)
+
+
 
 
 class AIR_PT_operation(bpy.types.Panel):


### PR DESCRIPTION
Implements #94 by adding a controlnet_weight float parameter and exposing that in the ControlNet UI panel.

![image](https://user-images.githubusercontent.com/1191379/232161872-833113aa-cc2a-492d-a7d4-4e1217f7fa4e.png)
